### PR TITLE
solving overflow issues

### DIFF
--- a/frontend/src/pages/Dashboard/Dashboard.css
+++ b/frontend/src/pages/Dashboard/Dashboard.css
@@ -25,6 +25,8 @@
   overflow-y: auto;
   font-size: 14px;
   line-height: 1.6;
+  overflow: hidden;
+  word-wrap: break-word;
 }
 
 .details-panel h3 {


### PR DESCRIPTION
pre
![aa](https://github.com/user-attachments/assets/d5df5fe6-52a0-4754-ab1d-d6a35853fc44)
post
![bb](https://github.com/user-attachments/assets/7f53b6a1-c90e-45b5-908a-58035095feef)

when using on lower res, the text overflowed from container, doing unwanted behaviour 