### PR TITLE
Add 'Find closest compounds' functionality

### DIFF
--- a/backend/app/Service.py
+++ b/backend/app/Service.py
@@ -26,6 +26,7 @@ class Service:
                 "distance" : distance
             })
 
+        result.sort(key=lambda comp: comp["distance"])
         return result
 
             

--- a/frontend/src/components/CompoundDetails/CompoundDetails.css
+++ b/frontend/src/components/CompoundDetails/CompoundDetails.css
@@ -9,7 +9,7 @@
 }
 
 .compound-info {
-    margin-top: 60px;
+    margin-top: 10px;
     font-size: 14px;
     line-height: 2;
     padding: 20px;

--- a/frontend/src/components/FindClosestCompounds/FindClosestCompounds.css
+++ b/frontend/src/components/FindClosestCompounds/FindClosestCompounds.css
@@ -1,0 +1,58 @@
+.find-closest-compounds {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding-left: 15px;
+    padding-right: 15px;
+    background-color: #f0f0f0;
+    border-radius: 8px;
+    margin-top: 10px;
+}
+
+.title {
+    font-size: 20px;
+    font-weight: bold;
+    color: #333;
+    margin-bottom: 10px;
+    text-align: center;
+}
+
+.input-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    gap: 10px;
+    margin-bottom: 15px;
+}
+
+.input-field {
+    width: 50%;
+    padding: 10px;
+    font-size: 16px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    box-sizing: border-box;
+}
+
+.input-field:focus {
+    border-color: #007bff;
+    outline: none;
+    box-shadow: 0 0 5px rgba(0, 123, 255, 0.5);
+}
+
+.find-button {
+    padding: 10px 20px;
+    font-size: 16px;
+    color: #fff;
+    background-color: #007bff;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+}
+
+.find-button:hover {
+    background-color: #0056b3;
+}

--- a/frontend/src/components/FindClosestCompounds/FindClosestCompounds.jsx
+++ b/frontend/src/components/FindClosestCompounds/FindClosestCompounds.jsx
@@ -1,0 +1,33 @@
+import './FindClosestCompounds.css';
+import React, { useState } from 'react';
+const FindClosestCompounds = ({ onClick }) => {
+    const [inputValue, setInputValue] = useState(null);
+
+    const handleInputChange = (e) => {
+        setInputValue(e.target.value);
+    };
+
+    return (
+        <div className="find-closest-compounds">
+            <h1 className="title">Find Closest Compounds</h1>
+            <div className="input-container">
+                <input
+                    className="input-field"
+                    type="number"
+                    min="0"
+                    placeholder="Enter a number"
+                    value={inputValue}
+                    onChange={handleInputChange}
+                />
+                <button
+                    className="find-button"
+                    onClick={() => onClick(Number(inputValue))}
+                >
+                    FIND
+                </button>
+            </div>
+        </div>
+    );
+};
+
+export default FindClosestCompounds;

--- a/frontend/src/components/ScatterPlot/ScatterPlot.jsx
+++ b/frontend/src/components/ScatterPlot/ScatterPlot.jsx
@@ -1,9 +1,106 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, memo, useRef } from "react";
 import Plot from "react-plotly.js";
 import ColorBySelect, { COLOR_BY_CRITERIUM } from "../ColorBySelect/ColorBySelect";
 import "./ScatterPlot.css";
+import { isSameCompound } from "../../pages/Dashboard/Dashboard";
 
-const preparePlotData = (rawData) => {
+const ScatterPlot = memo(function ScatterPlot({ onClick, selectedCompound, closestCompounds }) {
+    const [colorBy, setColorBy] = useState(COLOR_BY_CRITERIUM.CONCENTRATION);
+    const [rawData, setRawData] = useState([]);
+    const [plotData, setPlotData] = useState([]);
+    const [layout, setLayout] = useState({
+        title: `Compounds colored by ${colorBy}`,
+        dragmode: "pan",
+        xaxis: { title: "" },
+        yaxis: { title: "" },
+        autosize: true,
+    });
+    const plotRef = useRef(null);
+
+    const fetchData = async (colorBy) => {
+        const apiURL = `http://127.0.0.1:8000/compounds/colored_by_${colorBy}`;
+        try {
+            const response = await fetch(apiURL);
+            const result = await response.json();
+            setRawData(result);
+            setPlotData(preparePlotData(result, selectedCompound, closestCompounds));
+        } catch (error) {
+            console.error("Error fetching data:", error);
+        }
+    };
+
+    useEffect(() => {
+        fetchData(colorBy);
+        setLayout(current => ({
+            ...current,
+            title: `Compounds colored by ${colorBy}`,
+        }));
+    }, [colorBy]);
+
+    useEffect(() => {
+        setPlotData(preparePlotData(rawData, selectedCompound, closestCompounds));
+    }, [selectedCompound, closestCompounds]);
+
+    const handlePlotClick = (e) => {
+        if (e.points && e.points.length > 0) {
+            onClick(e.points[0]);
+        }
+    };
+
+    const onRelayout = (newLayout) => {
+        setLayout(current => ({
+            ...current,
+            xaxis: newLayout['xaxis'] || current.xaxis,
+            yaxis: newLayout['yaxis'] || current.yaxis
+        }));
+    };
+
+    return (
+        <>
+            <ColorBySelect 
+                colorBy={colorBy}
+                onChange={(selectedOption) => setColorBy(selectedOption.value)}
+            />
+            <div className="plotly-container">
+                <Plot
+                    ref={plotRef}
+                    data={plotData}
+                    layout={layout}
+                    useResizeHandler={true}
+                    style={{ width: "100%", height: "100%" }}
+                    config={{
+                        scrollZoom: true,
+                    }}
+                    onClick={handlePlotClick}
+                    onRelayout={onRelayout}
+                />
+            </div>
+        </>
+    );
+});
+
+
+const preparePlotData = (rawData, selectedCompound, closestCompounds) => {
+    const closestCompoundsSet = new Set(
+        closestCompounds.map(c => `${c.name}|${c.concentration}`)
+    );
+
+    const getPointSize = (point) => {
+        return isSameCompound(point, selectedCompound) 
+            ? 24
+            : closestCompoundsSet.has(`${point.name}|${point.concentration}`)
+                ? 16
+                : 12;
+    }
+
+    const getPointBorderWidth = (point) => {
+        return isSameCompound(point, selectedCompound)
+            ? 4
+            : closestCompoundsSet.has(`${point.name}|${point.concentration}`)
+                ? 2
+                : 0;
+    }
+
     return [
         {
             x: rawData.map((point) => point.x),
@@ -11,11 +108,16 @@ const preparePlotData = (rawData) => {
             mode: "markers",
             type: "scatter",
             marker: {
-                size: 12,
+                size: rawData.map(getPointSize),
                 color: rawData.map(
                     (point) =>
                         `rgb(${point.color.R},${point.color.G},${point.color.B})`
                 ),
+                opacity: 1,
+                line: {
+                    color: "black",
+                    width: rawData.map(getPointBorderWidth),
+                }
             },
             text: rawData.map((point) => point.name),
             customdata: rawData.map((point) => ({
@@ -26,52 +128,5 @@ const preparePlotData = (rawData) => {
         },
     ];
 };
-
-function ScatterPlot({ onClick }) {
-    const [colorBy, setColorBy] = useState(COLOR_BY_CRITERIUM.CONCENTRATION);
-    const [plotData, setPlotData] = useState();
-
-    const fetchData = async (colorBy) => {
-        const apiURL = `http://127.0.0.1:8888/compounds/colored_by_${colorBy}`;
-        try {
-            const response = await fetch(apiURL);
-            const result = await response.json();
-            setPlotData(preparePlotData(result));
-        } catch (error) {
-            console.error("Error fetching data:", error);
-        }
-    };
-
-    useEffect(() => {
-        fetchData(colorBy);
-    }, [colorBy]);
-
-    return (
-        <>
-            <ColorBySelect 
-                colorBy={colorBy}
-                onChange={(selectedOption) => setColorBy(selectedOption.value)}
-            />
-            <div className="plotly-container">
-                <Plot
-                    data={plotData}
-                    layout={{
-                        title: `Compounds colored by ${colorBy}`,
-                        dragmode: "pan",
-                        xaxis: { title: "" },
-                        yaxis: { title: "" },
-                        autosize: true,
-                    }}
-                    useResizeHandler={true}
-                    style={{ width: "100%", height: "100%" }}
-                    config={{
-                        scrollZoom: true,
-                    }}
-                    onClick={(e) => onClick(e.points[0].customdata)}
-                />
-            </div>
-        </>
-    );
-}
 
 export default ScatterPlot;

--- a/frontend/src/pages/Dashboard/Dashboard.css
+++ b/frontend/src/pages/Dashboard/Dashboard.css
@@ -6,6 +6,8 @@
 }
 
 .scatter-plot-container {
+  min-width: calc(100% - 600px);
+  max-width: calc(100% - 400px);
   flex: 2;
   display: flex;
   flex-direction: column;
@@ -22,10 +24,10 @@
   flex: 1;
   padding: 20px;
   background-color: #fff;
-  overflow-y: auto;
   font-size: 14px;
   line-height: 1.6;
   overflow: hidden;
+  overflow-y: auto;
   word-wrap: break-word;
 }
 

--- a/frontend/src/pages/Dashboard/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard/Dashboard.jsx
@@ -2,11 +2,41 @@ import { useState } from "react";
 import ScatterPlot from "../../components/ScatterPlot/ScatterPlot";
 import CompoundDetails from "../../components/CompoundDetails/CompoundDetails";
 import './Dashboard.css';
+import FindClosestCompounds from "../../components/FindClosestCompounds/FindClosestCompounds";
 
 function Dashboard() {
     const [selectedCompound, setSelectedCompound] = useState(null);
+    const [compoundsSortedByDistance, setCompoundsSortedByDistance] = useState([]);
+    const [numberOfClosestCompounds, setNumberOfClosestCompounds] = useState(0);
 
-    const handlePointClick = async ({ name, concentration }) => {
+    const handleFindClosestClick = async (numberOfCompounds) => {
+        if (numberOfCompounds <= 0) {
+            return;
+        }
+
+        setNumberOfClosestCompounds(numberOfCompounds);
+        if (selectedCompound && (!compoundsSortedByDistance.length ||
+                !isSameCompound(selectedCompound, compoundsSortedByDistance[0]))) {
+
+            const apiURL = `http://127.0.0.1:8000/compound/distances/${selectedCompound.name}/${selectedCompound.concentration}`
+            try {
+                const response = await fetch(apiURL);
+                const result = await response.json();
+                setCompoundsSortedByDistance(result);
+            } catch (error) {
+                console.error('Error fetching data:', error);
+            }
+        }
+    }
+
+    const handlePointClick = async (point) => {
+        if (isSameCompound(selectedCompound, point.customdata)) {
+            return;
+        }
+
+        setCompoundsSortedByDistance([]);
+        setNumberOfClosestCompounds(0);
+        const { name, concentration } = point.customdata;
         const apiURL = `http://127.0.0.1:8000/compound/details/${name}/${concentration}`
         try {
             const response = await fetch(apiURL);
@@ -26,14 +56,22 @@ function Dashboard() {
         <div className="dashboard-container">
             <div className="scatter-plot-container">
                 <div className="control-panel">
-                    <ScatterPlot onClick={handlePointClick} />
+                    <ScatterPlot 
+                        onClick={handlePointClick} 
+                        selectedCompound={selectedCompound}
+                        closestCompounds={compoundsSortedByDistance?.slice(0, numberOfClosestCompounds + 1)}
+                    />
                 </div>
             </div>
             <div className="details-panel">
                 <CompoundDetails compoundData={selectedCompound} />
+                <FindClosestCompounds onClick={handleFindClosestClick}/>
             </div>
         </div>
     );
 }
+
+export const isSameCompound = (compound1, compound2) => 
+    compound1?.name === compound2?.name && compound1?.concentration === compound2?.concentration;
 
 export default Dashboard


### PR DESCRIPTION
Changes:
- The points returned from the distances endpoint are now sorted by distance.
- Added `FindClosestCompounds` component, where the user can input the number of closest compounds to display.
When the Find button is clicked, a request is made to the `distances` endpoint — but only if the distances haven’t already been fetched for the selected compound. This is checked by comparing `selectedCompound` with `compoundsSortedByDistance[0]`. If they match, the distances have already been fetched and no new request is made. The fetched distances are stored in the state of the `Dashboard` component. The number of closest compounds to display is also stored in the state. The resulting list of nearest compounds is then passed to the `ScatterPlot` component, which highlights them on the plot.
- Also added highlight for selected compound on the chart

![image](https://github.com/user-attachments/assets/54d15530-9b4f-4143-8844-1186875b1b56)
